### PR TITLE
cpu, dmesg: superuser priviledge is not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,10 +442,10 @@ sudo lsusb [-v]
 - CPU Info
 
 ```
-sudo dmesg
-sudo dmesg | sed -n '/^CPU:/,/^real/p'
-sudo sysctl hw.model hw.ncpu
-sudo sysctl kern.smp.cpus
+dmesg
+dmesg | sed -n '/^CPU:/,/^real/p'
+sysctl hw.model hw.ncpu
+sysctl kern.smp.cpus
 ```
 
 ## Memory commands


### PR DESCRIPTION
Commands such as `dmesg`, `sysctl` don't require elevated privilege to run. In GNU/Linux `dmesg`, however, requires elevated priviledges to run.